### PR TITLE
Add Azure SQL Support to Distributed Testing Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.19'
     implementation 'org.apache.commons:commons-csv:1.1'
     implementation group: 'org.jetbrains', name: 'annotations', version: '13.0'
+    implementation 'com.microsoft.azure:azure:1.3.0'
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.2"
 }

--- a/src/main/groovy/com/r3/testing/KubesTest.java
+++ b/src/main/groovy/com/r3/testing/KubesTest.java
@@ -81,8 +81,8 @@ public class KubesTest extends DefaultTask {
         String stableRunId = rnd64Base36(new Random(buildId.hashCode() + currentUser.hashCode() + taskToExecuteName.hashCode()));
         String random = rnd64Base36(new Random());
 
-        // Tear down any orphaned db schemas from previous test run
-        tearDownOrphanedAzureSQLDbSchemas();
+        // Tear down any orphaned dbs from previous test run
+        tearDownOrphanedAzureSQLDbs();
 
         try (KubernetesClient client = getKubernetesClient()) {
             client.pods().inNamespace(NAMESPACE).list().getItems().forEach(podToDelete -> {
@@ -115,11 +115,11 @@ public class KubesTest extends DefaultTask {
             }
         }).collect(Collectors.toList());
 
-        // Tear down Azure SQL DB schemas (if any) from this test run
-        tearDownAzureSQLDbSchemas(stableRunId, random);
+        // Tear down Azure SQL DBs (if any) from this test run
+        tearDownAzureSQLDbs(stableRunId, random);
     }
 
-    private void tearDownOrphanedAzureSQLDbSchemas() {
+    private void tearDownOrphanedAzureSQLDbs() {
         // get all of the live pod names
         try (KubernetesClient client = getKubernetesClient()) {
             List<String> podNames = client.pods().inNamespace(NAMESPACE).list().getItems().stream().map(pod -> pod.getMetadata().getName()).collect(Collectors.toList());
@@ -143,7 +143,7 @@ public class KubesTest extends DefaultTask {
         }
     }
 
-    private void tearDownAzureSQLDbSchemas(String stableRunId, String random) {
+    private void tearDownAzureSQLDbs(String stableRunId, String random) {
         if (additionalArgs.stream().anyMatch(arg -> arg.contains("azure"))) {
             List<String> podNames = IntStream.range(0, numberOfPods).mapToObj(i -> generatePodName(stableRunId, random, i)).collect(Collectors.toList());
             String basePodName = podNames.get(0).substring(0, podNames.get(0).length() - 2);

--- a/src/main/groovy/com/r3/testing/KubesTest.java
+++ b/src/main/groovy/com/r3/testing/KubesTest.java
@@ -382,7 +382,7 @@ public class KubesTest extends DefaultTask {
                 .usingListener(execListener)
                 .exec(buildCommand);
 
-        startLogPumping(stdOutIs, podIdx, podLogsDirectory, printOutput);
+        startLogPumping(stdOutIs, podIdx, outputFileForPod, printOutput);
         return waiter;
     }
 

--- a/src/main/groovy/com/r3/testing/KubesTest.java
+++ b/src/main/groovy/com/r3/testing/KubesTest.java
@@ -491,7 +491,7 @@ public class KubesTest extends DefaultTask {
                 .withNewResources();
     }
 
-    private void startLogPumping(InputStream stdOutIs, int podIdx, File outputFile, boolean printOutput) throws IOException {
+    private void startLogPumping(InputStream stdOutIs, int podIdx, File outputFile, boolean printOutput) {
 
         Thread loggingThread = new Thread(() -> {
             try (BufferedWriter out = new BufferedWriter(new FileWriter(outputFile, true));


### PR DESCRIPTION
### Context
Azure SQL requires distributed integration tests to be handled differently to standard database flavours.

When kicking off the distributed test tasks for standard dbs, the db docker image is specified, along with any additional required arguments (db setup scripts, jdbc connection string etc). Each created pod is comprised of two containers: one running the project image and another running the db image.

### Changes
This PR introduces changes to make the plugin compatible with Azure SQL.
When running the Azure SQL distributed test task, Azure SQL dbs are set-up and subsequently torn down pre and post test run, using the Azure Java API. A sidecar db image should not be specified this case. Each pod consists of a single container running the project image and the tests are run against the newly created dbs.

A database server `eng-infra-test-db-server-01` has been created under the `build-k8s-infrastructure` resource group, on which the databases are created.

### Further work
Following on from this, the distributed test task must be added to the Corda Enterprise build.gradle, and changes must be made to the Jenkinsfile so that the task can triggered on-demand by PR comments.

### Other
Note that Azure service principal credentials must be supplied as command line arguments like so:
`./gradlew allAzureSQLParallelDatabaseIntegrationTest -Dkubenetize -Ddocker.push.password=yourdockercontainerregistrypassword -Ddocker.run.tag=ba59cca5-ad3  -Dazure.client="http://service-principal" -Dazure.tenant=a7bd1f2e-2d10-4185-87cd-236aca9b672c -Dazure.key=31b658b3-eb0b-41da-8a1d-3780ca6575ca`