### PR TITLE
Fix new task hierarchy placement issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                             "-Ddocker.push.password=\"\${DOCKER_PUSH_PWD}\" " +
                             "-Ddocker.work.dir=\"/tmp/\${EXECUTOR_NUMBER}\" " +
                             "-Ddocker.build.tag=\"\${DOCKER_TAG_TO_USE}\"" +
-                            " clean pushBuildImage preAllocateForAllParallelUnitTest --stacktrace"
+                            " clean pushBuildImage --stacktrace"
                 }
                 sh "kubectl auth can-i get pods"
             }
@@ -38,7 +38,7 @@ pipeline {
                         "-Dartifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
                         "-Dgit.branch=\"\${GIT_BRANCH}\" " +
                         "-Dgit.target.branch=\"\${CHANGE_TARGET}\" " +
-                        " deAllocateForAllParallelUnitTest allParallelUnitTest --stacktrace"
+                        " allParallelUnitTest --stacktrace"
             }
         }
     }

--- a/src/main/java/com/r3/testing/DistributedTesting.java
+++ b/src/main/java/com/r3/testing/DistributedTesting.java
@@ -15,7 +15,7 @@ class DistributedTesting implements Plugin<Project> {
     public void apply(Project project) {
         if (System.getProperty("kubenetize") != null) {
             Properties.setRootProjectType(project.getRootProject().getName());
-            Kubernetizer.forProject(DistributedTestingProject.forProject(project)).kubernetize();
+            Kubernetizer.configuredWith(DistributedTestingConfiguration.fromSystem()).kubernetize(project);
         }
 
         //  Added only so that we can manually run zipTask on the command line as a test.

--- a/src/main/java/com/r3/testing/DistributedTestingConfiguration.java
+++ b/src/main/java/com/r3/testing/DistributedTestingConfiguration.java
@@ -1,0 +1,20 @@
+package com.r3.testing;
+
+public final class DistributedTestingConfiguration {
+
+    public static DistributedTestingConfiguration fromSystem() {
+        return new DistributedTestingConfiguration(
+                System.getProperty(ImageBuilding.PROVIDE_TAG_FOR_RUNNING_PROPERTY)
+        );
+    }
+
+    private final String tagToUseForRunningTests;
+
+    public DistributedTestingConfiguration(String tagToUseForRunningTests) {
+        this.tagToUseForRunningTests = tagToUseForRunningTests;
+    }
+
+    public String getTagToUseForRunningTests() {
+        return tagToUseForRunningTests;
+    }
+}

--- a/src/main/java/com/r3/testing/DistributedTestingProject.java
+++ b/src/main/java/com/r3/testing/DistributedTestingProject.java
@@ -92,7 +92,8 @@ public final class DistributedTestingProject {
     public void traverseParallelTestGroups(ParallelTestGroupConfigurer configurer) {
         Map<String, List<Test>> testsGroupedByType = getTestsGroupedByType();
 
-        project.getTasks().withType(ParallelTestGroup.class).stream().distinct().forEach(parallelTestGroup ->
+        Set<ParallelTestGroup> parallelTestGroups = new HashSet<>(project.getTasks().withType(ParallelTestGroup.class));
+        parallelTestGroups.forEach(parallelTestGroup ->
                 configurer.configureParallelTestGroup(
                     parallelTestGroup,
                     parallelTestGroup.getGroups().stream()

--- a/src/main/java/com/r3/testing/DistributedTestingSubProject.java
+++ b/src/main/java/com/r3/testing/DistributedTestingSubProject.java
@@ -36,7 +36,7 @@ public final class DistributedTestingSubProject {
     }
 
     private <T extends Task> T createTask(String prefix, Task task, Class<T> taskType, Consumer<T> configure) {
-        return subProject.getRootProject().getTasks().create(newTaskName(prefix, task), taskType, configure::accept);
+        return subProject.getTasks().create(newTaskName(prefix, task), taskType, configure::accept);
     }
 
     public ListTests createListTestsTaskFor(Test task, Consumer<ListTests> configure) {

--- a/src/main/java/com/r3/testing/Kubernetizer.java
+++ b/src/main/java/com/r3/testing/Kubernetizer.java
@@ -2,63 +2,54 @@ package com.r3.testing;
 
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage;
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage;
-import groovy.lang.Closure;
-import org.apache.commons.lang3.StringUtils;
-import org.gradle.api.tasks.testing.Test;
-import org.gradle.api.tasks.testing.TestDescriptor;
-import org.gradle.api.tasks.testing.TestResult;
-import org.jetbrains.annotations.NotNull;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.*;
-import java.util.stream.Collectors;
+import org.gradle.api.Project;
 
 public final class Kubernetizer {
 
-    public static Kubernetizer forProject(DistributedTestingProject project) {
-        ImageBuilding imagePlugin = project.getImageBuildingPlugin();
+    public static Kubernetizer configuredWith(DistributedTestingConfiguration configuration) {
+        return new Kubernetizer(configuration);
+    }
+
+    private final DistributedTestingConfiguration configuration;
+
+    private Kubernetizer(DistributedTestingConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    public void kubernetize(Project project) {
+        DistributedTestingProject distributedTestingProject = DistributedTestingProject.forProject(project);
+
+        ImageBuilding imagePlugin = distributedTestingProject.getImageBuildingPlugin();
         DockerPushImage imagePushTask = imagePlugin.pushTask;
         DockerBuildImage imageBuildTask = imagePlugin.buildTask;
 
-        String tagToUseForRunningTests = System.getProperty(ImageBuilding.PROVIDE_TAG_FOR_RUNNING_PROPERTY);
-        BucketingAllocatorTask globalAllocator = project.createGlobalAllocator();
+        String tagToUseForRunningTests = configuration.getTagToUseForRunningTests();
+        BucketingAllocatorTask globalAllocator = distributedTestingProject.createGlobalAllocator();
 
-        TestDistributor testDistributor = new TestDistributor(project, globalAllocator, imagePushTask, tagToUseForRunningTests);
-        ParallelTestGroupConfigurer parallelTestGroupConfigurer = new ParallelTestGroupConfigurer(project, imageBuildTask, imagePushTask, tagToUseForRunningTests);
+        TestDistributor testDistributor = new TestDistributor(
+                distributedTestingProject,
+                globalAllocator,
+                imagePushTask,
+                tagToUseForRunningTests);
 
-        return new Kubernetizer(
-                project,
-                testDistributor,
-                parallelTestGroupConfigurer
-        );
-    }
+        ParallelTestGroupConfigurer parallelTestGroupConfigurer = new ParallelTestGroupConfigurer(
+                distributedTestingProject,
+                imageBuildTask,
+                imagePushTask,
+                tagToUseForRunningTests);
 
-    private final DistributedTestingProject project;
-    private final TestDistributor testDistributor;
-    private final ParallelTestGroupConfigurer parallelTestGroupConfigurer;
-
-    private Kubernetizer(DistributedTestingProject project, TestDistributor testDistributor, ParallelTestGroupConfigurer parallelTestGroupConfigurer) {
-        this.project = project;
-        this.testDistributor = testDistributor;
-        this.parallelTestGroupConfigurer = parallelTestGroupConfigurer;
-    }
-
-    public void kubernetize() {
         //in each subproject
         //1. add the task to determine all tests within the module and register this as a source to the global allocator
         //2. modify the underlying testing task to use the output of the global allocator to include a subset of tests for each fork
         //3. KubesTest will invoke these test tasks in a parallel fashion on a remote k8s cluster
         //4. after each completed test write its name to a file to keep track of what finished for restart purposes
-        project.traverseRequestedTasks(testDistributor);
+        distributedTestingProject.traverseRequestedTasks(testDistributor);
 
         //first step is to create a single task which will invoke all the submodule tasks for each grouping
         //ie allParallelTest will invoke [node:test, core:test, client:rpc:test ... etc]
         //ie allIntegrationTest will invoke [node:integrationTest, core:integrationTest, client:rpc:integrationTest ... etc]
         //ie allUnitAndIntegrationTest will invoke [node:integrationTest, node:test, core:integrationTest, core:test, client:rpc:test , client:rpc:integrationTest ... etc]
-        project.traverseParallelTestGroups(parallelTestGroupConfigurer);
+        distributedTestingProject.traverseParallelTestGroups(parallelTestGroupConfigurer);
     }
 
 }

--- a/src/test/groovy/com/r3/testing/KubernetizerTest.java
+++ b/src/test/groovy/com/r3/testing/KubernetizerTest.java
@@ -21,8 +21,7 @@ public class KubernetizerTest {
         testProject.getTasks().create("testClasses", org.gradle.api.tasks.testing.Test.class, test -> test.setGroup("test"));
         testProject.getGradle().getStartParameter().setTaskNames(Arrays.asList("test"));
 
-        Kubernetizer kubernetizer = Kubernetizer.forProject(DistributedTestingProject.forProject(testProject));
-        kubernetizer.kubernetize();
+        Kubernetizer.configuredWith(DistributedTestingConfiguration.fromSystem()).kubernetize(testProject);
 
         List<String> resultingTaskNames = testProject.getTasks().stream().map(Task::getName).collect(Collectors.toList());
 


### PR DESCRIPTION
The creation of parallel test tasks for subprojects was failing because they were being created in the root project, and tasks with the same task name (`foo:test`, `bar:test`) were clashing.

Additionally there was a `ConcurrentModificationException` when iterating over parallel test groups.

This PR fixes both issues (and also slightly tidies up the API for `Kubernetizer`, as a first step towards eliminating calls to `System.getProperty` at ad hoc locations throughout the plugin code).