### PR TITLE
INFRA-291 - MSSQL on-demand test fix

### DIFF
--- a/src/main/java/com/r3/testing/SupportedDatabase.java
+++ b/src/main/java/com/r3/testing/SupportedDatabase.java
@@ -1,0 +1,64 @@
+package com.r3.testing;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum SupportedDatabase {
+
+    POSTGRES {
+        @Override
+        public String asLowerCase() {
+            return POSTGRES.toString().toLowerCase();
+        }
+        
+        @Override
+        public String getDBContainerSuffix() {
+            return "-pg";
+        }
+
+        @Override
+        public Map<String, String> getEnvVars(List<String> additionalArgs) {
+            return new HashMap<String, String>() {
+                {
+                    put("POSTGRES_HOST_AUTH_METHOD", "trust");
+                }
+            };
+        }
+    }, MSSQL {
+        @Override
+        public String asLowerCase() {
+            return MSSQL.toString().toLowerCase();
+        }
+        
+        @Override
+        public String getDBContainerSuffix() {
+            return "-mssql";
+        }
+
+        @Override
+        public Map<String, String> getEnvVars(List<String> additionalArgs) {
+            return new HashMap<String, String>() {
+                {
+                    put("ACCEPT_EULA", "Y");
+                    put("SA_PASSWORD", getMSSQLDBPassword(additionalArgs));
+                }
+            };
+        }
+    };
+
+    public abstract String asLowerCase();
+    public abstract String getDBContainerSuffix();
+    public abstract Map<String, String> getEnvVars(List<String> additionalArgs);
+
+    public static String getMSSQLDBPassword(List<String> additionalArgs) {
+        if (additionalArgs.stream().noneMatch(arg -> arg.contains("test.db.admin.password"))) {
+            throw new IllegalArgumentException("Couldn't find `test.db.admin.password` in MSSQL parallel database" +
+                    "integration test task additional arguments list. Check host project build.gradle configuration.");
+        }
+        return additionalArgs.stream().filter(arg -> arg.contains("test.db.admin.password"))
+                .map(arg -> arg.replaceAll(".*=", "")).collect(Collectors.joining());
+
+    }
+}


### PR DESCRIPTION
### Changes
This PR ensures that the `SA_PASSWORD` environment variable is set on MSSQL container startup so that the jdbc connection from the worker container is successful, and the tests can be run.

It appears that the MSSQL tests have always been broken. Prior to improved Jenkins test reporting, the test task would appear at a glance to complete successfully overall, despite numerous failing tests.

The subsequent introduction of improved Jenkins test reporting ensures that a full breakdown of test failures from on-demand test tasks is captured and the unstable build is indicated clearly by the yellow ball.

### Testing
A dummy ENT PR depending on a test version of the plugin was raised to observe the MSSQL on-demand tests working properly in Jenkins.