### PR TITLE
INFRA-301 - Azure SQL integration

### DIFF
--- a/src/main/java/com/r3/testing/KubesTest.java
+++ b/src/main/java/com/r3/testing/KubesTest.java
@@ -743,7 +743,7 @@ public class KubesTest extends DefaultTask {
         if (additionalArgs == null || additionalArgs.isEmpty()
                 || additionalArgs.stream().noneMatch(arg -> arg.contains("custom.databaseProvider"))) {
             throw new IllegalArgumentException("No `custom.databaseProvider` specified in ParallelTestGroup task.");
-        } else if (additionalArgs.stream().anyMatch(arg -> arg.contains("azure"))) {
+        } else if (additionalArgs.stream().anyMatch(arg -> arg.contains(SupportedDatabase.AZURE.asLowerCase()))) {
             return SupportedDatabase.AZURE;
         } else {
             for (SupportedDatabase db : SupportedDatabase.values()) {

--- a/src/main/java/com/r3/testing/SupportedDatabase.java
+++ b/src/main/java/com/r3/testing/SupportedDatabase.java
@@ -1,5 +1,6 @@
 package com.r3.testing;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,21 @@ public enum SupportedDatabase {
                     put("SA_PASSWORD", getMSSQLDBPassword(additionalArgs));
                 }
             };
+        }
+    }, AZURE {
+        @Override
+        public String asLowerCase() {
+            return AZURE.toString().toLowerCase();
+        }
+
+        @Override
+        public String getDBContainerSuffix() {
+            throw new IllegalStateException("DB container not required for AzureSQL");
+        }
+
+        @Override
+        public Map<String, String> getEnvVars(List<String> additionalArgs) {
+            return Collections.emptyMap();
         }
     };
 


### PR DESCRIPTION
### Changes
This PR fixes the plugin's Azure SQL distributed integration test support.
- Pod lifespan gets increased from `3600` to `7200` seconds in the case of Azure SQL tests, as the basic tier DBs used are insufficiently performant to guarantee test completion otherwise.
- Azure SQL database server has been modified, now pointing to `sqlserver://asql-int-test.database.windows.net:1433`. This is reflected in the test task in ENT.
- DB setup and tear down has been fixed.

### Related PRs
https://github.com/corda/enterprise/pull/3359
https://github.com/corda/corda-shared-build-pipeline-steps/pull/5