### PR TITLE
INFRA-301 - Load Azure SQL credentials from Jenkins

### DIFF
--- a/src/main/java/com/r3/testing/KubesTest.java
+++ b/src/main/java/com/r3/testing/KubesTest.java
@@ -420,6 +420,9 @@ public class KubesTest extends DefaultTask {
         if (additionalArgs.stream().anyMatch(arg -> arg.contains(SupportedDatabase.AZURE.asLowerCase()))) {
             // Azure SQL
             setUpAzureSQLDBSchemaForPod(podName);
+            additionalArgs.add("-Dcorda.dataSourceProperties.dataSource.url=" + System.getProperty("infra.asql.db.url"));
+            additionalArgs.add("-Dtest.db.admin.user=" + System.getProperty("infra.asql.db.user"));
+            additionalArgs.add("-Dtest.db.admin.password=" + System.getProperty("infra.asql.db.password"));
             return buildPodRequestWithOnlyWorkerNode(podName, pvc, podIdx);
         } else if (withDB) {
             // Postgres, MSSQL


### PR DESCRIPTION
### Changes
Modify plugin to load Azure SQL credentials from system properties to prevent them from being exposed in the ENT root `build.gradle`.

### Related
https://github.com/corda/corda-shared-build-pipeline-steps/pull/6
