### PR TITLE
INFRA-300 - Add Oracle

### DIFF
--- a/src/main/java/com/r3/testing/KubesTest.java
+++ b/src/main/java/com/r3/testing/KubesTest.java
@@ -423,7 +423,7 @@ public class KubesTest extends DefaultTask {
             addAdditionalArgsForAzureSQL();
             return buildPodRequestWithOnlyWorkerNode(podName, pvc, podIdx);
         } else if (withDB) {
-            // Postgres, MSSQL
+            // Postgres, MSSQL, Oracle
             return buildPodRequestWithWorkerNodeAndDBContainer(podName, pvc, podIdx);
         } else {
             // No DB / H2

--- a/src/main/java/com/r3/testing/SupportedDatabase.java
+++ b/src/main/java/com/r3/testing/SupportedDatabase.java
@@ -47,7 +47,23 @@ public enum SupportedDatabase {
                 }
             };
         }
-    }, AZURE {
+    }, ORACLE {
+        @Override
+        public String asLowerCase() {
+            return ORACLE.toString().toLowerCase();
+        }
+
+        @Override
+        public String getDBContainerSuffix() {
+            return "-orcl";
+        }
+
+        @Override
+        public Map<String, String> getEnvVars(List<String> additionalArgs) {
+            return Collections.emptyMap();
+        }
+    },
+    AZURE {
         @Override
         public String asLowerCase() {
             return AZURE.toString().toLowerCase();
@@ -55,7 +71,7 @@ public enum SupportedDatabase {
 
         @Override
         public String getDBContainerSuffix() {
-            throw new IllegalStateException("DB container not required for AzureSQL");
+            throw new IllegalStateException("DB container not required for AzureSQL.");
         }
 
         @Override


### PR DESCRIPTION
### Changes
Adds Oracle as `SupportedDatabase` flavour. No other changes necessary to the infrastructure to support Oracle distributed on-demand database integration tests.