### PR TITLE
INFRA-391 - Add backwards compatible gradle plugin install script

### DIFF
--- a/src/main/java/com/r3/testing/KubesTest.java
+++ b/src/main/java/com/r3/testing/KubesTest.java
@@ -650,11 +650,30 @@ public class KubesTest extends DefaultTask {
                 artifactoryPassword +
                 "-Dkubenetize -PdockerFork=" + podIdx + " -PdockerForks=" + numberOfPods + " " + fullTaskToExecutePath + " " + getAdditionalArgs(podName) + " " + getLoggingLevel() + " 2>&1) ; " +
                 "let rs=$? ; sleep 10 ; exit ${rs}";
+
+        shellScript = getGradlePluginInstallScript() + " ; " + shellScript;
+
         return new String[]{"bash", "-c", shellScript};
     }
 
     private String getAdditionalArgs(String podName) {
         return this.additionalArgs.isEmpty() ? "" : String.join(" ", reworkDBNameForAzureSQL(this.additionalArgs, podName));
+    }
+
+    private String getGradlePluginInstallScript() {
+        // This exists for backwards compatibility with the
+        // now removed gradle plugins - some older builds
+        // may need to install them locally (eg; 3.0 backports)
+        return "if [ -f \"gradle-plugins/settings.gradle\" ] ; then ( " +
+                    "cd \"gradle-plugins/publish-utils\" ; " +
+                    "../../gradlew -u install ; " +
+                    "cd ../ ; " +
+                    "../gradlew install ; " +
+                    "echo \"done gradle install\" ) ; " +
+                // Erase any existing .m2 plugins to avoid clashes
+                "elif [ -d \"~/.m2/repository/net/corda/plugins\" ] ; then " +
+                    "rm -r \"~/.m2/repository/net/corda/plugins\" ; " +
+                "fi";
     }
 
     private List<String> reworkDBNameForAzureSQL(List<String> additionalArgs, String podName) {


### PR DESCRIPTION
### Changes
A number of the TeamCity jobs being migrated to Jenkins have a "Backwards compatible gradle plugins install" step. 

Example: https://ci-master.corda.r3cev.com/admin/editRunType.html?id=buildType:CordaEnterprise_BuildTags&runnerId=RUNNER_115&cameFromUrl=%2Fadmin%2FeditBuildRunners.html%3Fid%3DbuildType%253ACordaEnterprise_BuildTags%26init%3D1&cameFromTitle=

This step will now be baked into distributed builds so the script will run on each pod if required.